### PR TITLE
Only show icon if enabled + other fixes

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -153,7 +153,8 @@ class Application extends App {
 		// default
 		return new DbLock(
 			$c->query('UserId'),
-			$c->query('OCP\IConfig')
+			$c->query('OCP\IConfig'),
+			$c->getServer()->getDatabaseConnection()
 		);
 
 	}

--- a/lib/ContactsMenu/Providers/ChatProvider.php
+++ b/lib/ContactsMenu/Providers/ChatProvider.php
@@ -58,24 +58,28 @@ class ChatProvider implements IProvider
                 $domain = trim($config->getAppValue('ojsxc', 'xmppDomain'));
             }
 
-            $localIm = $uid.'@'.$domain;
-            $chatUrl = 'xmpp:'.$localIm;
+            if ($domain !== "") {
+                $localIm = $uid.'@'.$domain;
+                $chatUrl = 'xmpp:'.$localIm;
 
-            $action = $this->actionFactory->newLinkAction($iconUrl, $localIm, $chatUrl);
-            $entry->addAction($action);
+                $action = $this->actionFactory->newLinkAction($iconUrl, $localIm, $chatUrl);
+                $entry->addAction($action);
+            }
         }
 
         $imProperties = $entry->getProperty('IMPP');
 
-        foreach ($imProperties as $externalIm) {
-            if (!preg_match("/^[a-z0-9\.\-_]+@[a-z0-9\.\-_]+$/i", $externalIm) || $externalIm === $localIm) {
-                continue;
+        if (!is_null($imProperties)) {
+            foreach ($imProperties as $externalIm) {
+                if (!preg_match("/^[a-z0-9\.\-_]+@[a-z0-9\.\-_]+$/i", $externalIm) || $externalIm === $localIm) {
+                    continue;
+                }
+
+                $chatUrl = 'xmpp:'.$externalIm;
+
+                $action = $this->actionFactory->newLinkAction($iconUrl, $externalIm, $chatUrl);
+                $entry->addAction($action);
             }
-
-            $chatUrl = 'xmpp:'.$externalIm;
-
-            $action = $this->actionFactory->newLinkAction($iconUrl, $externalIm, $chatUrl);
-            $entry->addAction($action);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-data-uri": "^0.2.0",
     "grunt-exec": "^1.0.1",
-    "grunt-sass": "1.0.0",
+    "grunt-sass": "2.0.0",
     "grunt-search": "^0.1.6",
     "grunt-text-replace": "~0.3.11",
-    "node-sass": "3.3.0"
+    "node-sass": "4.5.2"
   }
 }

--- a/scss/jsxc.oc.scss
+++ b/scss/jsxc.oc.scss
@@ -17,7 +17,7 @@ $window_bar_color_hover: #fff;
         'js/jsxc/scss/window',
         'js/jsxc/scss/muc';
 
-@import 'js/jsxc/scss/jsxc';
+@import 'js/jsxc/scss/_jsxc.scss';
 @import 'js/jsxc/scss/webrtc';
 
 @import '_oc';


### PR DESCRIPTION
This fixes a few things:
 1. don't show the chat icon in the contacts menu when there is no backend enabled. This to prevent an error in nextcloud.log (see https://help.nextcloud.com/t/nextcloud-12-and-chat-ojsx-integration-doesnt-work/12973/1) and to prevent:
![schermafbeelding 2017-05-25 om 09 33 44](https://cloud.githubusercontent.com/assets/2996275/26440582/42dc1b32-412d-11e7-8122-50887cc449ef.png)
 2. the locking mechanism using the database. This was a bit broken since #12, we can't use the `getAppValue` since this use some caching (IIRC) and we need real-time results. This resulted in that the `http-bind` request was only sleeping for  max. 1 second instead of max. 10 (10 x 1 second)
 3. some changes to `package.json` to support nodejs 7 (I took the same versions as in jsxc/jsxc) (I'm fine with removing them again)