### PR TITLE
Resource is sometimes needed now (e.g. in presence) fixes presence

### DIFF
--- a/lib/db/stanzamapper.php
+++ b/lib/db/stanzamapper.php
@@ -53,8 +53,8 @@ class StanzaMapper extends Mapper {
 		$stmt = $this->execute("SELECT stanza, id FROM *PREFIX*ojsxc_stanzas WHERE `to`=?", [$to]);
 		$results = [];
 		while($row = $stmt->fetch()){
-			$row['stanza'] = preg_replace('/to="([^"@]*)"/', "to=\"$1@" .$this->host ."\"", $row['stanza']);
-			$row['stanza'] = preg_replace('/from="([^"@]*)"/', "from=\"$1@" .$this->host ."\"", $row['stanza']);
+			$row['stanza'] = preg_replace('/to="([^"@]*)"/', "to=\"$1@" .$this->host ."/internal\"", $row['stanza']);
+			$row['stanza'] = preg_replace('/from="([^"@]*)"/', "from=\"$1@" .$this->host ."/internal\"", $row['stanza']);
 			$results[] = $this->mapRowToEntity($row);
 		}
 		$stmt->closeCursor();


### PR DESCRIPTION
Presence wasn't working anymore in the latest release (see user report https://help.nextcloud.com/t/ojsxc-online-status-of-users-not-visible-also-no-user-information-loadable/13184) 

I'm quite sure this is caused since this change https://github.com/jsxc/jsxc/commit/ac55184ffb5d1f167b882be30520b297708b969f, because before this PR the internal XMPP server didn't send any resource so the else was triggered and now it isn't.

I think the best solution is to patch this on the server, especially if this is more XMPP compatible.

@sualko the user is asking for a time frame to release these two PR's (https://help.nextcloud.com/t/ojsxc-online-status-of-users-not-visible-also-no-user-information-loadable/13184/3), do you have any idea? Thanks :)