### PR TITLE
Fix - preffer mail address to login

### DIFF
--- a/ajax/getSettings.php
+++ b/ajax/getSettings.php
@@ -68,7 +68,9 @@ if (validateBoolean($config->getAppValue('ojsxc', 'xmppPreferMail'))) {
 }
 
 if (validateBoolean($config->getAppValue('ojsxc', 'timeLimitedToken'))) {
-   $data['xmpp']['username'] = $currentUID;
+   if($data['xmpp']['username'] == null) {
+       $data['xmpp']['username'] = $currentUID;
+   }
    $jid = $data['xmpp']['username'] . '@' . $data['xmpp']['domain'];
    $expiry = time() + 60*60;
    $secret = $config->getAppValue('ojsxc', 'apiSecret');


### PR DESCRIPTION
Currently when xmppPreferMail is true and $data ['xmpp'] ['username'] is set, it is overwritten with $currentUID, rendering log in to XMPP with email address not functioning.