### PR TITLE
Use "IIconSection" for admin settings in Nextcloud 12.

### DIFF
--- a/lib/Settings/Section.php
+++ b/lib/Settings/Section.php
@@ -6,7 +6,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\ISection;
 
-class Section implements ISection
+class SectionBase implements ISection
 {
     /** @var IL10N */
     private $l;
@@ -61,4 +61,13 @@ class Section implements ISection
     {
         return $this->url->imagePath('ojsxc', 'chat-icon.svg');
     }
+}
+
+$version = \OCP\Util::getVersion();
+if ($version[0] >= 12) {
+        class Section extends SectionBase implements \OCP\Settings\IIconSection {
+        }
+} else {
+        class Section extends SectionBase {
+        }
 }


### PR DESCRIPTION
With this change, the section shows the chat icon in Nextcloud 12. The `Section` class is created dynamically to still support Nextcloud < 12 which doesn't have the `IIconSection` interface.