### PR TITLE
Allow plain usernames without domain for sharedRoster

### DIFF
--- a/lib/Controller/ExternalApiController.php
+++ b/lib/Controller/ExternalApiController.php
@@ -141,18 +141,25 @@ class ExternalApiController extends SignatureProtectedApiController
 	*/
 	public function sharedRoster($username = '', $domain = '')
 	{
+		$currentUser = null;
 		if (!empty($username)) {
 			if (!empty($domain)) {
-				$username .= '@' . $domain;
+				$currentUser = $this->userManager->get($username . '@' . $domain);
 			}
-		} else {
-			throw new UnprocessableException('No username provided');
+			if (!$currentUser) {
+				$currentUser = $this->userManager->get($username);
+			}
+		}
+
+		if (!$currentUser) {
+			return [
+				'result' => 'failure',
+			];
 		}
 
 		$roster = [];
-		$user = $this->userManager->get($username);
 
-		$userGroups = $this->groupManager->getUserGroups($user);
+		$userGroups = $this->groupManager->getUserGroups($currentUser);
 
 		foreach ($userGroups as $userGroup) {
 			foreach ($userGroup->getUsers() as $user) {

--- a/lib/Controller/ExternalApiController.php
+++ b/lib/Controller/ExternalApiController.php
@@ -152,9 +152,7 @@ class ExternalApiController extends SignatureProtectedApiController
 		}
 
 		if (!$currentUser) {
-			return [
-				'result' => 'failure',
-			];
+			throw new UnprocessableException('Can\'t find user');
 		}
 
 		$roster = [];

--- a/tests/unit/controller/ExternalApiControllerTest.php
+++ b/tests/unit/controller/ExternalApiControllerTest.php
@@ -184,7 +184,7 @@ class ExternalApiControllerTest extends TestCase
 	public function testSharedRosterWithoutUsername()
 	{
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('No username provided');
+		$this->expectExceptionMessage('Can\'t find user');
 
 		$this->externalApiController->sharedRoster();
 	}


### PR DESCRIPTION
Similar to auth() and isuser()