### PR TITLE
Handle missing .github.json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "js/jsxc"]
 	path = js/jsxc
-	url = https://github.com/sualko/jsxc.git
+	url = https://github.com/jsxc/jsxc.git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: install
 	grunt build
 install:
-	git submodule update --init --recursive --remote
+	git submodule update --init --recursive
 	(cd js/jsxc/ && npm install)
 	(cd js/jsxc/ && bower install)
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-all: install
+.PHONY: all install
+all: install .github.json
 	grunt build
 install:
-	git submodule update --init --recursive
-	(cd js/jsxc/ && npm install)
-	(cd js/jsxc/ && bower install)
+	git submodule update --init
 	npm install
+	bower install
+# Does not exist on normal machines, create dummy
+.github.json:
+	echo '{}' > .github.json

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 .PHONY: all install
-all: install .github.json
+all: install
 	grunt build
 install:
-	git submodule update --init
+	git submodule update --init --recursive --remote
+	(cd js/jsxc/ && npm install)
+	(cd js/jsxc/ && bower install)
 	npm install
-	bower install
-# Does not exist on normal machines, create dummy
-.github.json:
-	echo '{}' > .github.json


### PR DESCRIPTION
Updated the Makefile to gracefully handle (i.e., essentially ignore) a missing `.github.json` on systems which do not need to initiate GitHub releases