### PR TITLE
Return at least user's full name with roster

### DIFF
--- a/lib/Controller/ExternalApiController.php
+++ b/lib/Controller/ExternalApiController.php
@@ -179,6 +179,12 @@ class ExternalApiController extends SignatureProtectedApiController
 				$roster[$uidMember]['groups'][] = $groupName;
 			}
 		}
+		if (empty($roster)) {
+			// The user is in no group, return fullname anyway
+			$roster[$currentUser->getUID()] = [
+					'name'=> $currentUser->getDisplayName()
+				];
+		}
 
 		return [
 		 'result' => 'success',


### PR DESCRIPTION
Even when the user is in no group. Allows the automatic setting of a minimal vcard in ejabberd → user friendly