### PR TITLE
Refactor UserId handling to use NC UserId in DB

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -73,7 +73,7 @@ if(!$apiSecret) {
    $config->setAppValue('ojsxc', 'apiSecret', $apiSecret);
 }
 
-if (Application::getServerType() === 'internal') {
+if (Application::getServerType() === Application::INTERNAL) {
 	Hooks::register();
 }
 

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -64,7 +64,7 @@ class Application extends App {
 			return new HttpBindController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$c->query('OJSXC_UserId'),
+				$c->query('UserId'),
 				$c->query('StanzaMapper'),
 				$c->query('IQHandler'),
 				$c->query('MessageHandler'),
@@ -161,7 +161,7 @@ class Application extends App {
 			return new PresenceMapper(
 				$container->getServer()->getDatabaseConnection(),
 				$c->query('Host'),
-				$c->query('OJSXC_UserId'),
+				$c->query('UserId'),
 				$c->query('MessageMapper'),
 				$c->query('NewContentContainer'),
 				self::$config['polling']['timeout'],
@@ -175,7 +175,7 @@ class Application extends App {
 		 */
 		$container->registerService('IQHandler', function(IContainer $c) {
 			return new IQ(
-				$c->query('OJSXC_UserId'),
+				$c->query('UserId'),
 				$c->query('Host'),
 				$c->query('OCP\IUserManager'),
 				$c->query('OCP\IConfig'),
@@ -185,7 +185,7 @@ class Application extends App {
 
 		$container->registerService('PresenceHandler', function(IContainer $c) {
 			return new Presence(
-				$c->query('OJSXC_UserId'),
+				$c->query('UserId'),
 				$c->query('Host'),
 				$c->query('PresenceMapper'),
 				$c->query('MessageMapper')
@@ -194,7 +194,7 @@ class Application extends App {
 
 		$container->registerService('MessageHandler', function(IContainer $c) {
 			return new Message(
-				$c->query('OJSXC_UserId'),
+				$c->query('UserId'),
 				$c->query('Host'),
 				$c->query('MessageMapper'),
 				$c->query('UserProvider'),
@@ -325,7 +325,7 @@ class Application extends App {
 			} else if ($cache->isAvailable()) {
 				$memcache = $cache->create('ojsxc');
 				return new MemLock(
-					$c->query('OJSXC_UserId'),
+					$c->query('UserId'),
 					$memcache
 				);
 			} else {
@@ -335,7 +335,7 @@ class Application extends App {
 
 		// default
 		return new DbLock(
-			$c->query('OJSXC_UserId'),
+			$c->query('UserId'),
 			$c->query('OCP\IConfig'),
 			$c->getServer()->getDatabaseConnection()
 		);

--- a/lib/db/stanza.php
+++ b/lib/db/stanza.php
@@ -25,23 +25,33 @@ class Stanza extends Entity implements XmlSerializable
 	}
 
 	/**
-	 * @var string $to
+	 * @var string $to The sanitized userId of the recipient of this stanza.
 	 */
 	public $to;
 
 	/**
-	 * @var string $to
+	 * @var string $from The sanitized userId of the sender of this stanza.
 	 */
 	public $from;
+
+	/**
+	 * @var string $to The userId (as stored in NC) of the recipient of this stanza.
+	 */
+	public $unSanitizedTo;
+
+	/**
+	 * @var string $from The userId (as stored in NC) of the sender of this stanza.
+	 */
+	public $unSanitizedFrom;
 
 	/**
 	 * @var string $stanza
 	 */
 	public $stanza;
 
-	public function getTo()
+	public function getUnSanitizedTo()
 	{
-		return $this->to;
+		return $this->unSanitizedTo;
 	}
 
 	/**
@@ -59,6 +69,7 @@ class Stanza extends Entity implements XmlSerializable
 			$userId = $userId[0];
 		}
 
+		$this->unSanitizedTo = $userId;
 		$this->to = Application::sanitizeUserId($userId);
 		if (!is_null($host_and_or_resource)) {
 			$this->to .= '@' . $host_and_or_resource;
@@ -79,15 +90,17 @@ class Stanza extends Entity implements XmlSerializable
 			$host_and_or_resource = $userId[1];
 			$userId = $userId[0];
 		}
+
+		$this->unSanitizedFrom = $userId;
 		$this->from = Application::sanitizeUserId($userId);
 		if (!is_null($host_and_or_resource)) {
 			$this->from .= '@' . $host_and_or_resource;
 		}
 	}
 
-	public function getFrom()
+	public function getUnSanitizedFrom()
 	{
-		return $this->from;
+		return $this->unSanitizedFrom;
 	}
 
 	public function xmlSerialize(Writer $writer)

--- a/lib/db/stanzamapper.php
+++ b/lib/db/stanzamapper.php
@@ -38,10 +38,10 @@ class StanzaMapper extends Mapper
 	}
 
 	/**
-	 * @param Entity $entity
+	 * @param Stanza $entity
 	 * @return void
 	 */
-	public function insert(Entity $entity)
+	public function insert(Stanza $entity)
 	{
 		$writer = new Writer();
 		$writer->openMemory();
@@ -52,7 +52,7 @@ class StanzaMapper extends Mapper
 
 		$sql = "INSERT INTO `*PREFIX*ojsxc_stanzas` (`to`, `from`, `stanza`) VALUES(?,?,?)";
 		$q = $this->db->prepare($sql);
-		$q->execute([$entity->getTo(), $entity->getFrom(), $xml]);
+		$q->execute([$entity->getUnSanitizedTo(), $entity->getUnSanitizedFrom(), $xml]);
 	}
 
 

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -2,7 +2,6 @@
 
 namespace OCA\OJSXC;
 
-use function foo\func;
 use OCA\OJSXC\AppInfo\Application;
 use OCA\OJSXC\Db\PresenceMapper;
 use OCA\OJSXC\Db\StanzaMapper;

--- a/lib/stanzahandlers/message.php
+++ b/lib/stanzahandlers/message.php
@@ -67,11 +67,10 @@ class Message extends StanzaHandler
 	 */
 	public function handle(array $stanza)
 	{
+		// Parse the username from the XML stanza to a NC userid
 		$to = $this->getAttribute($stanza, 'to');
 		$pos = strrpos($to, '@');
-
 		$this->to = substr($to, 0, $pos);
-
 		$this->to = Application::convertToRealUID(Application::deSanitize($this->to));
 
 		if (!$this->userProvider->hasUserByUID($this->to)) {

--- a/tests/integration/db/IqRosterPushTest.php
+++ b/tests/integration/db/IqRosterPushTest.php
@@ -22,7 +22,7 @@ class IqRosterPushTest extends TestCase
 		$iqRosterPush->setSubscription('both');
 
 		$this->assertEquals('john@localhost', $iqRosterPush->getJid());
-		$this->assertEquals('jan@localhost', $iqRosterPush->getTo());
+		$this->assertEquals('jan@localhost', $iqRosterPush->getUnSanitizedTo());
 		$this->assertEquals('john', $iqRosterPush->getName());
 		$this->assertEquals('both', $iqRosterPush->getSubscription());
 

--- a/tests/integration/db/IqRosterTest.php
+++ b/tests/integration/db/IqRosterTest.php
@@ -23,7 +23,7 @@ class IqRosterTest extends TestCase
 		$iqRoster->addItem('test2@test.be', 'Test2 Test');
 
 		$this->assertEquals('result', $iqRoster->getType());
-		$this->assertEquals('john@localhost', $iqRoster->getTo());
+		$this->assertEquals('john@localhost', $iqRoster->getUnSanitizedTo());
 		$this->assertEquals(4434, $iqRoster->getQid());
 		$this->assertEquals([
 			[

--- a/tests/integration/db/MessageMapperTest.php
+++ b/tests/integration/db/MessageMapperTest.php
@@ -57,8 +57,8 @@ class MessageMapperTest extends MapperTestUtility
 		$stanza->setType($type);
 		$stanza->setValue($msg);
 
-		$this->assertEquals($stanza->getFrom(), $from[0]);
-		$this->assertEquals($stanza->getTo(), $to[0]);
+		$this->assertEquals($stanza->getUnSanitizedFrom(), $from[0]);
+		$this->assertEquals($stanza->getUnSanitizedTo(), $to[0]);
 		$this->assertEquals($stanza->getStanza(), $data);
 		$this->assertEquals($stanza->getType(), $type);
 
@@ -67,8 +67,8 @@ class MessageMapperTest extends MapperTestUtility
 		$result = $this->fetchAll();
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($stanza->getFrom(), $result[0]->getFrom());
-		$this->assertEquals($stanza->getTo(), $result[0]->getTo());
+		$this->assertEquals($stanza->getUnSanitizedFrom(), $result[0]->getFrom());
+		$this->assertEquals($stanza->getUnSanitizedTo(), $result[0]->getTo());
 		$this->assertEquals($expectedStanza, $result[0]->getStanza());
 		$this->assertEquals(null, $result[0]->getType()); // type is saved into the XML string, not the DB.
 	}
@@ -128,8 +128,8 @@ class MessageMapperTest extends MapperTestUtility
 		// check if element is deleted
 		$result = $this->fetchAll();
 		$this->assertCount(1, $result);
-		$this->assertEquals($stanza2->getFrom(), $result[0]->getFrom());
-		$this->assertEquals($stanza2->getTo(), $result[0]->getTo());
+		$this->assertEquals($stanza2->getUnSanitizedFrom(), $result[0]->getFrom());
+		$this->assertEquals($stanza2->getUnSanitizedTo(), $result[0]->getTo());
 		$this->assertEquals('<message to="jan" from="thomas" type="test2" xmlns="jabber:client" id="4-msg">Message</message>', $result[0]->getStanza()); // notice that the username isn't replaced by the JID since this tis the task of hte findByTo method
 	}
 
@@ -166,8 +166,8 @@ class MessageMapperTest extends MapperTestUtility
 		// check if element is deleted
 		$result = $this->fetchAll();
 		$this->assertCount(1, $result);
-		$this->assertEquals($stanza2->getFrom(), $result[0]->getFrom());
-		$this->assertEquals($stanza2->getTo(), $result[0]->getTo());
+		$this->assertEquals($stanza2->getUnSanitizedFrom(), $result[0]->getFrom());
+		$this->assertEquals($stanza2->getUnSanitizedTo(), $result[0]->getTo());
 		$this->assertEquals('<message to="jan_ojsxc_esc_at_localhost.com" from="thomas_ojsxc_esc_at_localhost.com" type="test2" xmlns="jabber:client" id="4-msg">Message</message>', $result[0]->getStanza());
 	}
 }

--- a/tests/integration/db/PresenceTest.php
+++ b/tests/integration/db/PresenceTest.php
@@ -57,8 +57,8 @@ class PresenceTest extends TestCase
 	{
 		$result = $reader->parse();
 		$result = $result['value'];
-		$this->assertEquals($expectedElement->getTo(), $result->getTo());
-		$this->assertEquals($expectedElement->getFrom(), $result->getFrom());
+		$this->assertEquals($expectedElement->getUnSanitizedTo(), $result->getTo());
+		$this->assertEquals($expectedElement->getUnSanitizedFrom(), $result->getFrom());
 		$this->assertEquals($expectedElement->getPresence(), $result->getPresence());
 		$this->assertEquals($expectedElement->getUserid(), $result->getUserid());
 	}
@@ -137,8 +137,8 @@ class PresenceTest extends TestCase
 		$writer->endElement();
 		$result = $writer->outputMemory();
 
-		$this->assertEquals($to, $presenceEntity->getTo());
-		$this->assertEquals($from, $presenceEntity->getFrom());
+		$this->assertEquals($to, $presenceEntity->getUnSanitizedTo());
+		$this->assertEquals($from, $presenceEntity->getUnSanitizedFrom());
 		$this->assertEquals($presence, $presenceEntity->getPresence());
 		$this->assertSabreXmlEqualsXml($expected, $result);
 	}

--- a/tests/integration/db/StanzaMapperTest.php
+++ b/tests/integration/db/StanzaMapperTest.php
@@ -44,8 +44,8 @@ class StanzaMapperTest extends MapperTestUtility
 		$stanza->setTo($to);
 		$stanza->setStanza($data);
 
-		$this->assertEquals($stanza->getFrom(), $from);
-		$this->assertEquals($stanza->getTo(), $to);
+		$this->assertEquals($stanza->getUnSanitizedFrom(), $from);
+		$this->assertEquals($stanza->getUnSanitizedTo(), $to);
 		$this->assertEquals($stanza->getStanza(), $data);
 
 		$this->mapper->insert($stanza);
@@ -53,8 +53,8 @@ class StanzaMapperTest extends MapperTestUtility
 		$result = $this->fetchAll();
 
 		$this->assertCount(1, $result);
-		$this->assertEquals($stanza->getFrom(), $result[0]->getFrom());
-		$this->assertEquals($stanza->getTo(), $result[0]->getTo());
+		$this->assertEquals($stanza->getUnSanitizedFrom(), $result[0]->getFrom());
+		$this->assertEquals($stanza->getUnSanitizedTo(), $result[0]->getTo());
 		$this->assertEquals($stanza->getStanza(), $result[0]->getStanza());
 	}
 
@@ -107,8 +107,8 @@ class StanzaMapperTest extends MapperTestUtility
 		// check if element is deleted
 		$result = $this->fetchAll();
 		$this->assertCount(1, $result);
-		$this->assertEquals($stanza2->getFrom(), $result[0]->getFrom());
-		$this->assertEquals($stanza2->getTo(), $result[0]->getTo());
+		$this->assertEquals($stanza2->getUnSanitizedFrom(), $result[0]->getFrom());
+		$this->assertEquals($stanza2->getUnSanitizedTo(), $result[0]->getTo());
 		$this->assertEquals($stanza2->getStanza(), $result[0]->getStanza());
 	}
 

--- a/tests/unit/stanzahandlers/IQTest.php
+++ b/tests/unit/stanzahandlers/IQTest.php
@@ -176,11 +176,11 @@ class IQTest extends TestCase
 		$result = $this->iq->handle($stanza);
 
 		if ($expected instanceof IQRoster) {
-			$this->assertEquals($expected->getFrom(), $result->getFrom());
+			$this->assertEquals($expected->getUnSanitizedFrom(), $result->getUnSanitizedFrom());
 			$this->assertEquals($expected->getId(), $result->getId());
 			$this->assertEquals($expected->getItems(), $result->getItems());
 			$this->assertEquals($expected->getQid(), $result->getQid());
-			$this->assertEquals($expected->getTo(), $result->getTo());
+			$this->assertEquals($expected->getUnSanitizedTo(), $result->getUnSanitizedTo());
 			$this->assertEquals($expected->getType(), $result->getType());
 			$this->assertEquals($expected->getStanza(), $result->getStanza());
 		} else {


### PR DESCRIPTION
Originally plan was to use the OJSXC_UserId everywhere because this
seemed to be the easiest solution. However in the DB this
introduced jsxc/jsxc#708, so now the NC UserId is used everywhere except
for XML strings and Stanzas which are received or going to be send.

Fixes jsxc/jsxc#708