### PR TITLE
fix: add back iceServers url

### DIFF
--- a/ts/Bootstrap.ts
+++ b/ts/Bootstrap.ts
@@ -64,6 +64,9 @@ export default class Bootstrap {
             defaultAvatar(element, name, jid);
          },
          onUserRequestsToGoOnline: this.onUserRequestsToGoOnline.bind(this),
+         RTCPeerConfig: {
+            url: OC.generateUrl('apps/ojsxc/settings/iceServers')
+         },
       });
 
       //For debugging


### PR DESCRIPTION
RTCPeerConfig setting was lost during jsxc 4.0.0 migration. We thus lost STUN/TURN custom configuration.
Fix this by adding back the iceServers settings url in jsxc init.